### PR TITLE
Run server as background service

### DIFF
--- a/MinecraftServiceWrapper.java
+++ b/MinecraftServiceWrapper.java
@@ -1,0 +1,273 @@
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+/**
+ * Windows Service Wrapper for Minecraft Server with MetricsBridge Mod Detection
+ * 
+ * This wrapper detects if the MetricsBridge mod is installed and:
+ * - If mod is present: Runs as Windows service
+ * - If mod is not present: Runs in terminal mode
+ */
+public class MinecraftServiceWrapper {
+    
+    private static final String MOD_ID = "metricsbridge";
+    private static final String MOD_FILE_PATTERN = "fabric-metrics-bridge";
+    private static final String MODS_DIR = "mods";
+    private static final String CONFIG_DIR = "config";
+    private static final String CONFIG_FILE = "metricsbridge.json";
+    
+    private static Process serverProcess;
+    private static boolean isServiceMode = false;
+    private static boolean shouldStop = false;
+    
+    public static void main(String[] args) {
+        System.out.println("Minecraft Service Wrapper v1.0");
+        System.out.println("Checking for MetricsBridge mod...");
+        
+        // Check if MetricsBridge mod is installed
+        boolean modInstalled = isMetricsBridgeInstalled();
+        
+        if (modInstalled) {
+            System.out.println("MetricsBridge mod detected - Starting as Windows service");
+            isServiceMode = true;
+            startAsService();
+        } else {
+            System.out.println("MetricsBridge mod not found - Starting in terminal mode");
+            isServiceMode = false;
+            startInTerminal();
+        }
+    }
+    
+    /**
+     * Check if MetricsBridge mod is installed by looking for the mod JAR file
+     */
+    private static boolean isMetricsBridgeInstalled() {
+        try {
+            Path modsPath = Paths.get(MODS_DIR);
+            if (!Files.exists(modsPath)) {
+                return false;
+            }
+            
+            // Look for MetricsBridge mod JAR file
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(modsPath, "*.jar")) {
+                for (Path jarFile : stream) {
+                    String fileName = jarFile.getFileName().toString().toLowerCase();
+                    if (fileName.contains(MOD_FILE_PATTERN.toLowerCase())) {
+                        System.out.println("Found MetricsBridge mod: " + jarFile.getFileName());
+                        return true;
+                    }
+                }
+            }
+            
+            // Also check if config file exists (indicates mod was previously installed)
+            Path configPath = Paths.get(CONFIG_DIR, CONFIG_FILE);
+            if (Files.exists(configPath)) {
+                System.out.println("Found MetricsBridge config file - assuming mod is installed");
+                return true;
+            }
+            
+        } catch (Exception e) {
+            System.err.println("Error checking for MetricsBridge mod: " + e.getMessage());
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Start the server as a Windows service
+     */
+    private static void startAsService() {
+        System.out.println("Starting Minecraft server as Windows service...");
+        
+        // Set up shutdown hook for graceful service shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("Service shutdown requested");
+            shouldStop = true;
+            if (serverProcess != null && serverProcess.isAlive()) {
+                System.out.println("Stopping Minecraft server...");
+                serverProcess.destroy();
+                try {
+                    serverProcess.waitFor(30, java.util.concurrent.TimeUnit.SECONDS);
+                    if (serverProcess.isAlive()) {
+                        System.out.println("Force killing server process...");
+                        serverProcess.destroyForcibly();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }));
+        
+        // Start the server process
+        startServerProcess();
+        
+        // Keep the service running
+        while (!shouldStop && serverProcess != null && serverProcess.isAlive()) {
+            try {
+                Thread.sleep(1000);
+                
+                // Check if server process died unexpectedly
+                if (!serverProcess.isAlive()) {
+                    System.out.println("Server process died unexpectedly, restarting...");
+                    Thread.sleep(5000); // Wait 5 seconds before restart
+                    startServerProcess();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        
+        System.out.println("Service stopped");
+    }
+    
+    /**
+     * Start the server in terminal mode
+     */
+    private static void startInTerminal() {
+        System.out.println("Starting Minecraft server in terminal mode...");
+        System.out.println("Press Ctrl+C to stop the server");
+        
+        // Set up shutdown hook for graceful terminal shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.out.println("\nShutdown requested");
+            shouldStop = true;
+            if (serverProcess != null && serverProcess.isAlive()) {
+                System.out.println("Stopping Minecraft server...");
+                serverProcess.destroy();
+                try {
+                    serverProcess.waitFor(30, java.util.concurrent.TimeUnit.SECONDS);
+                    if (serverProcess.isAlive()) {
+                        System.out.println("Force killing server process...");
+                        serverProcess.destroyForcibly();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }));
+        
+        // Start the server process
+        startServerProcess();
+        
+        // Keep the terminal running and forward output
+        if (serverProcess != null) {
+            // Forward server output to console
+            Thread outputThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(serverProcess.getInputStream()))) {
+                    String line;
+                    while ((line = reader.readLine()) != null && !shouldStop) {
+                        System.out.println(line);
+                    }
+                } catch (IOException e) {
+                    if (!shouldStop) {
+                        System.err.println("Error reading server output: " + e.getMessage());
+                    }
+                }
+            });
+            outputThread.setDaemon(true);
+            outputThread.start();
+            
+            // Forward server error output to console
+            Thread errorThread = new Thread(() -> {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(serverProcess.getErrorStream()))) {
+                    String line;
+                    while ((line = reader.readLine()) != null && !shouldStop) {
+                        System.err.println(line);
+                    }
+                } catch (IOException e) {
+                    if (!shouldStop) {
+                        System.err.println("Error reading server error output: " + e.getMessage());
+                    }
+                }
+            });
+            errorThread.setDaemon(true);
+            errorThread.start();
+            
+            // Wait for server process to finish
+            try {
+                int exitCode = serverProcess.waitFor();
+                System.out.println("Server process exited with code: " + exitCode);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                System.out.println("Interrupted while waiting for server process");
+            }
+        }
+    }
+    
+    /**
+     * Start the actual Minecraft server process
+     */
+    private static void startServerProcess() {
+        try {
+            // Build the command to start the server
+            List<String> command = new ArrayList<>();
+            command.add("java");
+            
+            // Add JVM arguments
+            command.add("-Xmx2G");
+            command.add("-Xms1G");
+            command.add("-XX:+UseG1GC");
+            command.add("-XX:+ParallelRefProcEnabled");
+            command.add("-XX:MaxGCPauseMillis=200");
+            command.add("-XX:+UnlockExperimentalVMOptions");
+            command.add("-XX:+DisableExplicitGC");
+            command.add("-XX:+AlwaysPreTouch");
+            command.add("-XX:G1NewSizePercent=30");
+            command.add("-XX:G1MaxNewSizePercent=40");
+            command.add("-XX:G1HeapRegionSize=8M");
+            command.add("-XX:G1ReservePercent=20");
+            command.add("-XX:G1HeapWastePercent=5");
+            command.add("-XX:G1MixedGCCountTarget=4");
+            command.add("-XX:InitiatingHeapOccupancyPercent=15");
+            command.add("-XX:G1MixedGCLiveThresholdPercent=90");
+            command.add("-XX:G1RSetUpdatingPauseTimePercent=5");
+            command.add("-XX:SurvivorRatio=32");
+            command.add("-XX:+PerfDisableSharedMem");
+            command.add("-XX:MaxTenuringThreshold=1");
+            command.add("-Dusing.aikars.flags=https://mcflags.emc.gs");
+            command.add("-Daikars.new.flags=true");
+            
+            // Add server JAR
+            command.add("-jar");
+            command.add("server.jar");
+            command.add("nogui");
+            
+            // Start the process
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.directory(new File("."));
+            pb.redirectErrorStream(false);
+            
+            System.out.println("Starting server with command: " + String.join(" ", command));
+            serverProcess = pb.start();
+            
+            if (isServiceMode) {
+                System.out.println("Minecraft server started as service (PID: " + serverProcess.pid() + ")");
+                System.out.println("MetricsBridge web interface available at: http://localhost:8765");
+            } else {
+                System.out.println("Minecraft server started in terminal mode (PID: " + serverProcess.pid() + ")");
+            }
+            
+        } catch (Exception e) {
+            System.err.println("Failed to start Minecraft server: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+    
+    /**
+     * Get the current working directory
+     */
+    private static String getCurrentDirectory() {
+        try {
+            return new File(".").getCanonicalPath();
+        } catch (IOException e) {
+            return System.getProperty("user.dir");
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -53,16 +53,73 @@ A comprehensive Minecraft Fabric mod that provides a web-based dashboard for mon
 
 **Note**: The JAR file is automatically built and released on GitHub when new versions are tagged.
 
-### Option 2: Service Installation (Linux)
+### Option 2: Service Installation
 
-For production servers, you can install the Minecraft server as a systemd service that automatically starts with the MetricsBridge mod.
+#### Windows Service Installation
 
-#### Prerequisites
+For Windows servers, you can install the Minecraft server as a Windows service that automatically detects the MetricsBridge mod and behaves accordingly:
+- **With MetricsBridge mod**: Runs as a background service
+- **Without MetricsBridge mod**: Runs in terminal mode
+
+##### Prerequisites
+- Windows 7/8/10/11 or Windows Server
+- Java 21+ installed
+- Administrator privileges
+
+##### Quick Installation
+1. Download the service files to your Minecraft server directory
+2. Right-click `install-windows-service.bat` and select "Run as administrator"
+3. Follow the on-screen prompts
+
+##### Manual Installation Steps
+1. **Download service files** to your Minecraft server directory:
+   - `MinecraftServiceWrapper.java`
+   - `install-windows-service.bat`
+   - `uninstall-windows-service.bat`
+
+2. **Run the installer** as Administrator:
+   ```cmd
+   install-windows-service.bat
+   ```
+
+3. **The installer will**:
+   - Check for Java installation
+   - Detect if MetricsBridge mod is installed
+   - Compile the service wrapper
+   - Install the Windows service
+   - Configure auto-start and recovery options
+
+##### Service Behavior
+- **MetricsBridge mod detected**: Server runs as background service
+- **No MetricsBridge mod**: Server runs in terminal mode (visible console)
+- **Auto-restart**: Service automatically restarts if it crashes
+- **Auto-start**: Service starts automatically when Windows boots
+
+##### Service Management
+Use Windows Services management console (`services.msc`) or command line:
+```cmd
+sc start MinecraftServer      # Start the service
+sc stop MinecraftServer       # Stop the service
+sc query MinecraftServer      # Check service status
+sc delete MinecraftServer     # Remove the service
+```
+
+##### Uninstallation
+```cmd
+# Run as Administrator
+uninstall-windows-service.bat
+```
+
+#### Linux Service Installation
+
+For production Linux servers, you can install the Minecraft server as a systemd service that automatically starts with the MetricsBridge mod.
+
+##### Prerequisites
 - Linux system with systemd
 - Java 21+ installed
 - Root/sudo access
 
-#### Quick Installation
+##### Quick Installation
 ```bash
 # Download the installation script
 wget https://raw.githubusercontent.com/yourusername/fabric-metrics-bridge/main/install-service.sh
@@ -72,7 +129,7 @@ chmod +x install-service.sh
 sudo ./install-service.sh
 ```
 
-#### Manual Installation Steps
+##### Manual Installation Steps
 1. **Create minecraft user and directories**:
    ```bash
    sudo groupadd -r minecraft
@@ -99,7 +156,7 @@ sudo ./install-service.sh
    sudo systemctl start minecraft-server
    ```
 
-#### Service Management
+##### Service Management
 The installation script creates a convenient management command:
 ```bash
 minecraft-server start     # Start the server
@@ -111,7 +168,7 @@ minecraft-server enable    # Enable auto-start on boot
 minecraft-server disable   # Disable auto-start on boot
 ```
 
-#### Uninstallation
+##### Uninstallation
 ```bash
 # Download and run the uninstall script
 wget https://raw.githubusercontent.com/yourusername/fabric-metrics-bridge/main/uninstall-service.sh
@@ -119,7 +176,7 @@ chmod +x uninstall-service.sh
 sudo ./uninstall-service.sh
 ```
 
-#### Service Configuration
+##### Service Configuration
 The service is configured with:
 - **User**: `minecraft` (dedicated system user)
 - **Directory**: `/opt/minecraft`

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A comprehensive Minecraft Fabric mod that provides a web-based dashboard for mon
 
 ## 🛠️ Installation
 
-### 1. Download and Install
+### Option 1: Manual Installation
 
 1. Go to the [Releases](https://github.com/yourusername/fabric-metrics-bridge/releases) page
 2. Download the latest `fabric-metrics-bridge.jar` from the latest release
@@ -52,6 +52,81 @@ A comprehensive Minecraft Fabric mod that provides a web-based dashboard for mon
 4. Start your server to generate the configuration file
 
 **Note**: The JAR file is automatically built and released on GitHub when new versions are tagged.
+
+### Option 2: Service Installation (Linux)
+
+For production servers, you can install the Minecraft server as a systemd service that automatically starts with the MetricsBridge mod.
+
+#### Prerequisites
+- Linux system with systemd
+- Java 21+ installed
+- Root/sudo access
+
+#### Quick Installation
+```bash
+# Download the installation script
+wget https://raw.githubusercontent.com/yourusername/fabric-metrics-bridge/main/install-service.sh
+chmod +x install-service.sh
+
+# Run the installation script
+sudo ./install-service.sh
+```
+
+#### Manual Installation Steps
+1. **Create minecraft user and directories**:
+   ```bash
+   sudo groupadd -r minecraft
+   sudo useradd -r -g minecraft -d /opt/minecraft -s /bin/false minecraft
+   sudo mkdir -p /opt/minecraft/{world,logs,config,mods}
+   sudo chown -R minecraft:minecraft /opt/minecraft
+   ```
+
+2. **Download Minecraft server and MetricsBridge mod**:
+   ```bash
+   # Download Minecraft server jar to /opt/minecraft/server.jar
+   # Download MetricsBridge mod to /opt/minecraft/mods/
+   ```
+
+3. **Install the service**:
+   ```bash
+   sudo cp minecraft-server.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable minecraft-server
+   ```
+
+4. **Start the service**:
+   ```bash
+   sudo systemctl start minecraft-server
+   ```
+
+#### Service Management
+The installation script creates a convenient management command:
+```bash
+minecraft-server start     # Start the server
+minecraft-server stop      # Stop the server
+minecraft-server restart   # Restart the server
+minecraft-server status    # Check server status
+minecraft-server logs      # View server logs
+minecraft-server enable    # Enable auto-start on boot
+minecraft-server disable   # Disable auto-start on boot
+```
+
+#### Uninstallation
+```bash
+# Download and run the uninstall script
+wget https://raw.githubusercontent.com/yourusername/fabric-metrics-bridge/main/uninstall-service.sh
+chmod +x uninstall-service.sh
+sudo ./uninstall-service.sh
+```
+
+#### Service Configuration
+The service is configured with:
+- **User**: `minecraft` (dedicated system user)
+- **Directory**: `/opt/minecraft`
+- **Memory**: 2GB max, 1GB initial
+- **Auto-restart**: Enabled with 10-second delay
+- **Logs**: Available via `journalctl -u minecraft-server`
+- **Security**: Runs with limited privileges and resource limits
 
 ### 2. Configuration
 

--- a/install-service.sh
+++ b/install-service.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+
+# Minecraft Server Service Installation Script
+# This script sets up a systemd service for running a Minecraft server with the MetricsBridge mod
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+MINECRAFT_USER="minecraft"
+MINECRAFT_GROUP="minecraft"
+MINECRAFT_DIR="/opt/minecraft"
+SERVICE_NAME="minecraft-server"
+SERVICE_FILE="minecraft-server.service"
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running as root
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        print_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+# Check if Java is installed
+check_java() {
+    if ! command -v java &> /dev/null; then
+        print_error "Java is not installed. Please install OpenJDK 21 first:"
+        echo "  Ubuntu/Debian: sudo apt install openjdk-21-jdk"
+        echo "  CentOS/RHEL: sudo yum install java-21-openjdk-devel"
+        echo "  Fedora: sudo dnf install java-21-openjdk-devel"
+        exit 1
+    fi
+    
+    # Check Java version
+    JAVA_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f1)
+    if [[ $JAVA_VERSION -lt 21 ]]; then
+        print_warning "Java version $JAVA_VERSION detected. Java 21 or higher is recommended for Minecraft 1.21.8"
+    fi
+    
+    print_success "Java is installed: $(java -version 2>&1 | head -n 1)"
+}
+
+# Create minecraft user and group
+create_user() {
+    if ! id "$MINECRAFT_USER" &>/dev/null; then
+        print_status "Creating minecraft user and group..."
+        groupadd -r "$MINECRAFT_GROUP"
+        useradd -r -g "$MINECRAFT_GROUP" -d "$MINECRAFT_DIR" -s /bin/false "$MINECRAFT_USER"
+        print_success "Created minecraft user and group"
+    else
+        print_status "Minecraft user already exists"
+    fi
+}
+
+# Create minecraft directory structure
+create_directories() {
+    print_status "Creating minecraft directory structure..."
+    
+    # Create main directory
+    mkdir -p "$MINECRAFT_DIR"
+    
+    # Create subdirectories
+    mkdir -p "$MINECRAFT_DIR"/{world,logs,config,mods,plugins}
+    mkdir -p /var/log/minecraft
+    
+    # Set ownership
+    chown -R "$MINECRAFT_USER:$MINECRAFT_GROUP" "$MINECRAFT_DIR"
+    chown -R "$MINECRAFT_USER:$MINECRAFT_GROUP" /var/log/minecraft
+    
+    # Set permissions
+    chmod 755 "$MINECRAFT_DIR"
+    chmod 755 /var/log/minecraft
+    
+    print_success "Created directory structure"
+}
+
+# Download and setup Minecraft server
+setup_server() {
+    print_status "Setting up Minecraft server..."
+    
+    # Check if server.jar already exists
+    if [[ -f "$MINECRAFT_DIR/server.jar" ]]; then
+        print_warning "server.jar already exists. Skipping download."
+        print_warning "Make sure you have the MetricsBridge mod installed in the mods/ directory"
+        return
+    fi
+    
+    # Download server jar (you'll need to provide the actual download URL)
+    print_warning "Please download the Minecraft server jar manually and place it at:"
+    print_warning "  $MINECRAFT_DIR/server.jar"
+    print_warning "You can download it from: https://www.minecraft.net/en-us/download/server"
+    print_warning "Also, make sure to install the MetricsBridge mod in:"
+    print_warning "  $MINECRAFT_DIR/mods/"
+    
+    # Create a placeholder eula.txt
+    echo "eula=true" > "$MINECRAFT_DIR/eula.txt"
+    chown "$MINECRAFT_USER:$MINECRAFT_GROUP" "$MINECRAFT_DIR/eula.txt"
+    
+    print_success "Server setup completed (manual download required)"
+}
+
+# Install systemd service
+install_service() {
+    print_status "Installing systemd service..."
+    
+    # Copy service file
+    cp "$SERVICE_FILE" "/etc/systemd/system/$SERVICE_NAME.service"
+    
+    # Reload systemd
+    systemctl daemon-reload
+    
+    # Enable service
+    systemctl enable "$SERVICE_NAME"
+    
+    print_success "Service installed and enabled"
+}
+
+# Configure firewall (optional)
+configure_firewall() {
+    if command -v ufw &> /dev/null; then
+        print_status "Configuring UFW firewall..."
+        ufw allow 25565/tcp comment "Minecraft Server"
+        ufw allow 8765/tcp comment "MetricsBridge Web Interface"
+        print_success "Firewall configured"
+    elif command -v firewall-cmd &> /dev/null; then
+        print_status "Configuring firewalld..."
+        firewall-cmd --permanent --add-port=25565/tcp
+        firewall-cmd --permanent --add-port=8765/tcp
+        firewall-cmd --reload
+        print_success "Firewall configured"
+    else
+        print_warning "No firewall detected. Make sure to open ports 25565 (Minecraft) and 8765 (MetricsBridge) manually"
+    fi
+}
+
+# Create management script
+create_management_script() {
+    print_status "Creating management script..."
+    
+    cat > /usr/local/bin/minecraft-server << 'EOF'
+#!/bin/bash
+
+# Minecraft Server Management Script
+
+SERVICE_NAME="minecraft-server"
+
+case "$1" in
+    start)
+        echo "Starting Minecraft server..."
+        sudo systemctl start $SERVICE_NAME
+        ;;
+    stop)
+        echo "Stopping Minecraft server..."
+        sudo systemctl stop $SERVICE_NAME
+        ;;
+    restart)
+        echo "Restarting Minecraft server..."
+        sudo systemctl restart $SERVICE_NAME
+        ;;
+    status)
+        sudo systemctl status $SERVICE_NAME
+        ;;
+    logs)
+        sudo journalctl -u $SERVICE_NAME -f
+        ;;
+    enable)
+        echo "Enabling Minecraft server to start on boot..."
+        sudo systemctl enable $SERVICE_NAME
+        ;;
+    disable)
+        echo "Disabling Minecraft server from starting on boot..."
+        sudo systemctl disable $SERVICE_NAME
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status|logs|enable|disable}"
+        echo ""
+        echo "Commands:"
+        echo "  start    - Start the Minecraft server"
+        echo "  stop     - Stop the Minecraft server"
+        echo "  restart  - Restart the Minecraft server"
+        echo "  status   - Show server status"
+        echo "  logs     - Show server logs (follow mode)"
+        echo "  enable   - Enable server to start on boot"
+        echo "  disable  - Disable server from starting on boot"
+        exit 1
+        ;;
+esac
+EOF
+
+    chmod +x /usr/local/bin/minecraft-server
+    print_success "Management script created at /usr/local/bin/minecraft-server"
+}
+
+# Main installation function
+main() {
+    print_status "Starting Minecraft Server Service Installation..."
+    echo ""
+    
+    check_root
+    check_java
+    create_user
+    create_directories
+    setup_server
+    install_service
+    configure_firewall
+    create_management_script
+    
+    echo ""
+    print_success "Installation completed successfully!"
+    echo ""
+    print_status "Next steps:"
+    echo "1. Download the Minecraft server jar and place it at: $MINECRAFT_DIR/server.jar"
+    echo "2. Install the MetricsBridge mod in: $MINECRAFT_DIR/mods/"
+    echo "3. Configure your server in: $MINECRAFT_DIR/server.properties"
+    echo "4. Configure MetricsBridge in: $MINECRAFT_DIR/config/metricsbridge.json"
+    echo "5. Start the server with: minecraft-server start"
+    echo ""
+    print_status "Useful commands:"
+    echo "  minecraft-server start    - Start the server"
+    echo "  minecraft-server stop     - Stop the server"
+    echo "  minecraft-server status   - Check server status"
+    echo "  minecraft-server logs     - View server logs"
+    echo ""
+    print_status "Web interface will be available at: http://your-server:8765"
+    print_status "Default MetricsBridge config:"
+    echo "  - Port: 8765"
+    echo "  - Shared Secret: change-me (CHANGE THIS!)"
+    echo "  - Allow Origins: * (configure for security)"
+}
+
+# Run main function
+main "$@"

--- a/install-windows-service.bat
+++ b/install-windows-service.bat
@@ -1,0 +1,193 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Minecraft Server Windows Service Installation Script
+REM This script installs the Minecraft server as a Windows service with MetricsBridge mod detection
+
+echo ========================================
+echo Minecraft Server Service Installer
+echo ========================================
+echo.
+
+REM Check if running as administrator
+net session >nul 2>&1
+if %errorLevel% neq 0 (
+    echo ERROR: This script must be run as Administrator
+    echo Right-click and select "Run as administrator"
+    pause
+    exit /b 1
+)
+
+REM Configuration
+set SERVICE_NAME=MinecraftServer
+set SERVICE_DISPLAY_NAME=Minecraft Server
+set SERVICE_DESCRIPTION=Minecraft Server with MetricsBridge Mod Detection
+set WRAPPER_JAR=MinecraftServiceWrapper.jar
+set WRAPPER_CLASS=MinecraftServiceWrapper
+set JAVA_HOME=%JAVA_HOME%
+set SERVER_DIR=%CD%
+
+echo Checking prerequisites...
+
+REM Check if Java is installed
+java -version >nul 2>&1
+if %errorLevel% neq 0 (
+    echo ERROR: Java is not installed or not in PATH
+    echo Please install Java 21 or higher and ensure it's in your PATH
+    echo Download from: https://adoptium.net/
+    pause
+    exit /b 1
+)
+
+REM Get Java version
+for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (
+    set JAVA_VERSION=%%g
+)
+echo Java version found: %JAVA_VERSION%
+
+REM Check if server.jar exists
+if not exist "server.jar" (
+    echo WARNING: server.jar not found in current directory
+    echo Please ensure you have downloaded the Minecraft server jar
+    echo and placed it in the same directory as this script
+    echo.
+    set /p CONTINUE="Continue anyway? (y/N): "
+    if /i not "!CONTINUE!"=="y" (
+        echo Installation cancelled
+        pause
+        exit /b 1
+    )
+)
+
+REM Check if MetricsBridge mod is installed
+set MOD_FOUND=0
+if exist "mods\*.jar" (
+    for %%f in (mods\*.jar) do (
+        echo %%~nxf | findstr /i "metricsbridge" >nul
+        if !errorLevel! equ 0 (
+            set MOD_FOUND=1
+            echo Found MetricsBridge mod: %%~nxf
+        )
+    )
+)
+
+if %MOD_FOUND% equ 0 (
+    echo WARNING: MetricsBridge mod not found in mods directory
+    echo The service will run in terminal mode until the mod is installed
+    echo.
+)
+
+REM Compile the service wrapper
+echo Compiling service wrapper...
+javac MinecraftServiceWrapper.java
+if %errorLevel% neq 0 (
+    echo ERROR: Failed to compile MinecraftServiceWrapper.java
+    echo Please ensure you have the Java Development Kit (JDK) installed
+    pause
+    exit /b 1
+)
+
+REM Create JAR file
+echo Creating service wrapper JAR...
+jar cf %WRAPPER_JAR% MinecraftServiceWrapper.class
+if %errorLevel% neq 0 (
+    echo ERROR: Failed to create service wrapper JAR
+    pause
+    exit /b 1
+)
+
+REM Clean up class file
+del MinecraftServiceWrapper.class
+
+echo Service wrapper compiled successfully
+
+REM Check if service already exists
+sc query %SERVICE_NAME% >nul 2>&1
+if %errorLevel% equ 0 (
+    echo Service %SERVICE_NAME% already exists
+    set /p REMOVE="Remove existing service? (y/N): "
+    if /i "!REMOVE!"=="y" (
+        echo Stopping existing service...
+        sc stop %SERVICE_NAME% >nul 2>&1
+        timeout /t 3 >nul
+        echo Removing existing service...
+        sc delete %SERVICE_NAME% >nul 2>&1
+        timeout /t 2 >nul
+    ) else (
+        echo Installation cancelled
+        pause
+        exit /b 1
+    )
+)
+
+REM Create the service
+echo Installing Windows service...
+sc create %SERVICE_NAME% ^
+    binPath= "java -jar \"%SERVER_DIR%\%WRAPPER_JAR%\"" ^
+    DisplayName= "%SERVICE_DESCRIPTION%" ^
+    start= auto ^
+    obj= "NT AUTHORITY\LocalService"
+
+if %errorLevel% neq 0 (
+    echo ERROR: Failed to create Windows service
+    echo Make sure you have administrator privileges
+    pause
+    exit /b 1
+)
+
+REM Configure service recovery options
+echo Configuring service recovery options...
+sc failure %SERVICE_NAME% reset= 86400 actions= restart/5000/restart/5000/restart/5000
+
+REM Set service description
+sc description %SERVICE_NAME% "%SERVICE_DESCRIPTION%"
+
+echo.
+echo ========================================
+echo Service Installation Complete!
+echo ========================================
+echo.
+echo Service Name: %SERVICE_NAME%
+echo Display Name: %SERVICE_DISPLAY_NAME%
+echo Description: %SERVICE_DESCRIPTION%
+echo.
+echo The service will:
+echo - Start automatically when Windows boots
+echo - Run as a service when MetricsBridge mod is installed
+echo - Run in terminal mode when MetricsBridge mod is not installed
+echo - Automatically restart if it crashes
+echo.
+
+if %MOD_FOUND% equ 1 (
+    echo MetricsBridge mod detected - service will start in service mode
+    echo Web interface will be available at: http://localhost:8765
+) else (
+    echo MetricsBridge mod not found - service will start in terminal mode
+    echo Install the mod to enable service mode and web interface
+)
+
+echo.
+echo Service Management Commands:
+echo   Start:   sc start %SERVICE_NAME%
+echo   Stop:    sc stop %SERVICE_NAME%
+echo   Status:  sc query %SERVICE_NAME%
+echo   Delete:  sc delete %SERVICE_NAME%
+echo.
+echo Or use the Windows Services management console (services.msc)
+echo.
+
+set /p START_NOW="Start the service now? (Y/n): "
+if /i not "!START_NOW!"=="n" (
+    echo Starting service...
+    sc start %SERVICE_NAME%
+    if %errorLevel% equ 0 (
+        echo Service started successfully!
+        echo Check the Windows Event Viewer for service logs
+    ) else (
+        echo Failed to start service. Check Windows Event Viewer for details.
+    )
+)
+
+echo.
+echo Installation complete!
+pause

--- a/minecraft-server.service
+++ b/minecraft-server.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Minecraft Server with MetricsBridge Mod
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=minecraft
+Group=minecraft
+WorkingDirectory=/opt/minecraft
+ExecStart=/usr/bin/java -Xmx2G -Xms1G -jar /opt/minecraft/server.jar nogui
+ExecStop=/bin/kill -TERM $MAINPID
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=minecraft-server
+
+# Security settings
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/minecraft
+ReadWritePaths=/var/log/minecraft
+
+# Resource limits
+LimitNOFILE=65536
+MemoryMax=4G
+
+# Environment variables
+Environment=JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+Environment=MINECRAFT_OPTS=-Xmx2G -Xms1G
+
+[Install]
+WantedBy=multi-user.target

--- a/uninstall-service.sh
+++ b/uninstall-service.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# Minecraft Server Service Uninstallation Script
+# This script removes the systemd service and related files for the Minecraft server
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+MINECRAFT_USER="minecraft"
+MINECRAFT_GROUP="minecraft"
+MINECRAFT_DIR="/opt/minecraft"
+SERVICE_NAME="minecraft-server"
+
+# Function to print colored output
+print_status() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if running as root
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        print_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+# Stop and disable service
+stop_service() {
+    print_status "Stopping and disabling Minecraft server service..."
+    
+    if systemctl is-active --quiet "$SERVICE_NAME"; then
+        systemctl stop "$SERVICE_NAME"
+        print_success "Service stopped"
+    else
+        print_status "Service is not running"
+    fi
+    
+    if systemctl is-enabled --quiet "$SERVICE_NAME"; then
+        systemctl disable "$SERVICE_NAME"
+        print_success "Service disabled"
+    else
+        print_status "Service is not enabled"
+    fi
+}
+
+# Remove systemd service file
+remove_service_file() {
+    print_status "Removing systemd service file..."
+    
+    if [[ -f "/etc/systemd/system/$SERVICE_NAME.service" ]]; then
+        rm "/etc/systemd/system/$SERVICE_NAME.service"
+        systemctl daemon-reload
+        print_success "Service file removed"
+    else
+        print_status "Service file not found"
+    fi
+}
+
+# Remove management script
+remove_management_script() {
+    print_status "Removing management script..."
+    
+    if [[ -f "/usr/local/bin/minecraft-server" ]]; then
+        rm "/usr/local/bin/minecraft-server"
+        print_success "Management script removed"
+    else
+        print_status "Management script not found"
+    fi
+}
+
+# Ask about removing minecraft user and data
+remove_user_and_data() {
+    echo ""
+    print_warning "Do you want to remove the minecraft user and all server data?"
+    print_warning "This will permanently delete:"
+    echo "  - User: $MINECRAFT_USER"
+    echo "  - Group: $MINECRAFT_GROUP"
+    echo "  - Directory: $MINECRAFT_DIR"
+    echo "  - Logs: /var/log/minecraft"
+    echo ""
+    read -p "Are you sure? (y/N): " -n 1 -r
+    echo ""
+    
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        print_status "Removing minecraft user and data..."
+        
+        # Remove log directory
+        if [[ -d "/var/log/minecraft" ]]; then
+            rm -rf "/var/log/minecraft"
+            print_success "Log directory removed"
+        fi
+        
+        # Remove minecraft directory
+        if [[ -d "$MINECRAFT_DIR" ]]; then
+            rm -rf "$MINECRAFT_DIR"
+            print_success "Minecraft directory removed"
+        fi
+        
+        # Remove user and group
+        if id "$MINECRAFT_USER" &>/dev/null; then
+            userdel "$MINECRAFT_USER"
+            print_success "Minecraft user removed"
+        fi
+        
+        if getent group "$MINECRAFT_GROUP" &>/dev/null; then
+            groupdel "$MINECRAFT_GROUP"
+            print_success "Minecraft group removed"
+        fi
+        
+        print_warning "All minecraft data has been permanently deleted!"
+    else
+        print_status "Keeping minecraft user and data"
+        print_status "You can manually remove them later if needed:"
+        echo "  sudo userdel $MINECRAFT_USER"
+        echo "  sudo groupdel $MINECRAFT_GROUP"
+        echo "  sudo rm -rf $MINECRAFT_DIR"
+        echo "  sudo rm -rf /var/log/minecraft"
+    fi
+}
+
+# Remove firewall rules (optional)
+remove_firewall_rules() {
+    if command -v ufw &> /dev/null; then
+        print_status "Removing UFW firewall rules..."
+        ufw delete allow 25565/tcp 2>/dev/null || true
+        ufw delete allow 8765/tcp 2>/dev/null || true
+        print_success "Firewall rules removed"
+    elif command -v firewall-cmd &> /dev/null; then
+        print_status "Removing firewalld rules..."
+        firewall-cmd --permanent --remove-port=25565/tcp 2>/dev/null || true
+        firewall-cmd --permanent --remove-port=8765/tcp 2>/dev/null || true
+        firewall-cmd --reload 2>/dev/null || true
+        print_success "Firewall rules removed"
+    else
+        print_status "No firewall detected, skipping firewall cleanup"
+    fi
+}
+
+# Main uninstallation function
+main() {
+    print_status "Starting Minecraft Server Service Uninstallation..."
+    echo ""
+    
+    check_root
+    stop_service
+    remove_service_file
+    remove_management_script
+    remove_firewall_rules
+    remove_user_and_data
+    
+    echo ""
+    print_success "Uninstallation completed successfully!"
+    echo ""
+    print_status "The Minecraft server service has been completely removed."
+    print_status "If you kept the minecraft user and data, you can still access them manually."
+}
+
+# Run main function
+main "$@"

--- a/uninstall-windows-service.bat
+++ b/uninstall-windows-service.bat
@@ -1,0 +1,118 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Minecraft Server Windows Service Uninstallation Script
+REM This script removes the Minecraft server Windows service
+
+echo ========================================
+echo Minecraft Server Service Uninstaller
+echo ========================================
+echo.
+
+REM Check if running as administrator
+net session >nul 2>&1
+if %errorLevel% neq 0 (
+    echo ERROR: This script must be run as Administrator
+    echo Right-click and select "Run as administrator"
+    pause
+    exit /b 1
+)
+
+REM Configuration
+set SERVICE_NAME=MinecraftServer
+set WRAPPER_JAR=MinecraftServiceWrapper.jar
+
+echo Checking if service exists...
+
+REM Check if service exists
+sc query %SERVICE_NAME% >nul 2>&1
+if %errorLevel% neq 0 (
+    echo Service %SERVICE_NAME% does not exist
+    echo Nothing to uninstall
+    pause
+    exit /b 0
+)
+
+echo Service %SERVICE_NAME% found
+echo.
+
+REM Show service status
+echo Current service status:
+sc query %SERVICE_NAME%
+echo.
+
+REM Ask for confirmation
+set /p CONFIRM="Are you sure you want to uninstall the Minecraft server service? (y/N): "
+if /i not "%CONFIRM%"=="y" (
+    echo Uninstallation cancelled
+    pause
+    exit /b 0
+)
+
+echo.
+echo Uninstalling service...
+
+REM Stop the service if it's running
+echo Stopping service...
+sc stop %SERVICE_NAME% >nul 2>&1
+if %errorLevel% equ 0 (
+    echo Service stopped successfully
+) else (
+    echo Service was not running or already stopped
+)
+
+REM Wait a moment for the service to fully stop
+echo Waiting for service to stop...
+timeout /t 3 >nul
+
+REM Delete the service
+echo Removing service...
+sc delete %SERVICE_NAME% >nul 2>&1
+if %errorLevel% equ 0 (
+    echo Service removed successfully
+) else (
+    echo ERROR: Failed to remove service
+    echo You may need to restart your computer and try again
+    pause
+    exit /b 1
+)
+
+REM Ask about removing wrapper files
+echo.
+set /p REMOVE_FILES="Remove service wrapper files? (Y/n): "
+if /i not "%REMOVE_FILES%"=="n" (
+    if exist "%WRAPPER_JAR%" (
+        del "%WRAPPER_JAR%"
+        echo Removed %WRAPPER_JAR%
+    )
+    if exist "MinecraftServiceWrapper.java" (
+        del "MinecraftServiceWrapper.java"
+        echo Removed MinecraftServiceWrapper.java
+    )
+    if exist "MinecraftServiceWrapper.class" (
+        del "MinecraftServiceWrapper.class"
+        echo Removed MinecraftServiceWrapper.class
+    )
+    echo Service wrapper files removed
+) else (
+    echo Service wrapper files kept
+)
+
+echo.
+echo ========================================
+echo Uninstallation Complete!
+echo ========================================
+echo.
+echo The Minecraft server service has been successfully removed.
+echo.
+echo Your Minecraft server files are still intact:
+echo - server.jar
+echo - world data
+echo - mods
+echo - config files
+echo.
+echo You can still run the server manually by double-clicking server.jar
+echo or using: java -jar server.jar nogui
+echo.
+
+pause


### PR DESCRIPTION
Enable running the Minecraft server with MetricsBridge as a systemd service on Linux for automatic startup and management.

---
<a href="https://cursor.com/background-agent?bcId=bc-13e001d0-1990-4ec6-8e8e-dd93bd71bb42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13e001d0-1990-4ec6-8e8e-dd93bd71bb42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

